### PR TITLE
Expand wardrobe catalog

### DIFF
--- a/mobile/lib/storage_service.dart
+++ b/mobile/lib/storage_service.dart
@@ -4,6 +4,7 @@ import 'outfit_record.dart';
 
 class StorageService {
   static const _key = 'outfit_history';
+  static const _wardrobeKey = 'wardrobe_catalog';
 
   /// Save a new record to local history
   static Future<void> saveRecord(OutfitRecord record) async {
@@ -20,5 +21,28 @@ class StorageService {
     return raw
         .map((str) => OutfitRecord.fromJson(jsonDecode(str)))
         .toList();
+  }
+
+  /// Load wardrobe catalog grouped by category
+  static Future<Map<String, List<String>>> loadWardrobe() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_wardrobeKey);
+    if (raw == null) {
+      return {
+        'tops': [],
+        'bottoms': [],
+        'shoes': [],
+        'outerwear': [],
+        'accessories': [],
+      };
+    }
+    final Map<String, dynamic> data = jsonDecode(raw);
+    return data.map((k, v) => MapEntry(k, List<String>.from(v)));
+  }
+
+  /// Persist wardrobe catalog locally
+  static Future<void> saveWardrobe(Map<String, List<String>> data) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_wardrobeKey, jsonEncode(data));
   }
 }


### PR DESCRIPTION
## Summary
- expand `WardrobePage` with a catalog for tops, bottoms, shoes, outerwear, and accessories
- store wardrobe items locally using `SharedPreferences`
- allow adding, editing and deleting wardrobe items

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fad1a89d4832496cc210f00327c44