### PR TITLE
Add backend and Flutter unit tests

### DIFF
--- a/Backend/tests/test_app.py
+++ b/Backend/tests/test_app.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import types
+import datetime
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import app
+
+class MockResponse:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+def test_get_weather_parsing(monkeypatch):
+    today = datetime.datetime.now().strftime('%Y-%m-%d')
+    sample = {
+        "current": {
+            "apparent_temperature": 10,
+            "temperature_2m": 12,
+            "wind_speed_10m": 5,
+            "cloudcover": 25,
+            "relative_humidity_2m": 40,
+            "uv_index": 3,
+            "precipitation": 0.1
+        },
+        "hourly": {
+            "time": [f"{today}T08:00", f"{today}T14:00", f"{today}T20:00"],
+            "temperature_2m": [12, 15, 9],
+            "wind_speed_10m": [5, 6, 4],
+            "cloudcover": [20, 50, 60],
+            "precipitation_probability": [10, 20, 30]
+        },
+        "daily": {
+            "temperature_2m_max": [16],
+            "temperature_2m_min": [8],
+            "precipitation_probability_max": [40]
+        }
+    }
+
+    def mock_get(url, params=None, headers=None):
+        if 'open-meteo' in url:
+            return MockResponse(sample)
+        else:
+            return MockResponse({"address": {"city": "Testville"}})
+
+    monkeypatch.setattr(app.requests, 'get', mock_get)
+
+    weather = app.get_weather(0, 0, units='imperial')
+    assert weather['city'] == 'Testville'
+    assert weather['actual_temperature'] == 53.6
+    assert weather['feels_like_temperature'] == 50.0
+    assert weather['hourly_forecast']['morning']['temp'] == 53.6
+    assert weather['hourly_forecast']['afternoon']['wind'] == 13
+    assert weather['rain_chance'] == 30
+
+
+def test_suggest_outfit():
+    outfit = app.suggest_outfit(
+        temp=40,
+        units='imperial',
+        wind=10,
+        rain=60,
+        humidity=30,
+        cloud=10,
+        time_of_day='morning'
+    )
+    expected = {
+        "Long sleeve shirt",
+        "Sweater",
+        "Chinos or jeans",
+        "Insulated jacket",
+        "Raincoat",
+        "Waterproof boots",
+        "Umbrella",
+        "Sunglasses"
+    }
+    assert set(outfit) == expected

--- a/mobile/test/recommendation_service_test.dart
+++ b/mobile/test/recommendation_service_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mobile/recommendation_service.dart';
+import 'package:mobile/storage_service.dart';
+import 'package:mobile/outfit_record.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('recommend picks frequent items from similar weather', () async {
+    final r1 = OutfitRecord(
+      date: DateTime.parse('2024-01-01T00:00:00Z'),
+      temp: 70,
+      uvIndex: 5,
+      precipitationMm: 0,
+      precipitationProb: 20,
+      items: ['hat', 'shirt'],
+    );
+    final r2 = OutfitRecord(
+      date: DateTime.parse('2024-01-02T00:00:00Z'),
+      temp: 72,
+      uvIndex: 4,
+      precipitationMm: 0,
+      precipitationProb: 20,
+      items: ['hat', 'pants'],
+    );
+    final r3 = OutfitRecord(
+      date: DateTime.parse('2024-01-03T00:00:00Z'),
+      temp: 85,
+      uvIndex: 8,
+      precipitationMm: 0,
+      precipitationProb: 0,
+      items: ['sunglasses'],
+    );
+
+    await StorageService.saveRecord(r1);
+    await StorageService.saveRecord(r2);
+    await StorageService.saveRecord(r3);
+
+    final recs = await RecommendationService.recommend(
+      temp: 71,
+      uvIndex: 5,
+      precipitationMm: 0,
+      precipitationProb: 20,
+      topN: 2,
+    );
+
+    expect(recs.contains('hat'), true);
+    expect(recs.length, 2);
+  });
+}

--- a/mobile/test/storage_service_test.dart
+++ b/mobile/test/storage_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mobile/storage_service.dart';
+import 'package:mobile/outfit_record.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('save and load record', () async {
+    final record = OutfitRecord(
+      date: DateTime.parse('2024-01-01T00:00:00Z'),
+      temp: 70,
+      uvIndex: 5,
+      precipitationMm: 0,
+      precipitationProb: 10,
+      items: ['hat', 'shirt'],
+    );
+
+    await StorageService.saveRecord(record);
+    final history = await StorageService.loadHistory();
+
+    expect(history.length, 1);
+    expect(history.first.temp, 70);
+    expect(history.first.items, ['hat', 'shirt']);
+  });
+}


### PR DESCRIPTION
## Summary
- add Python tests for weather and outfit logic
- test Flutter storage and recommendation services

## Testing
- `pytest Backend/tests -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fad8b50648324849ee0a2ab0cda1d