### PR TITLE
Fix wind speed and precipitation parsing

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -38,7 +38,9 @@ def get_weather(lat, lon, units='imperial'):
         "current": "temperature_2m,apparent_temperature,precipitation,cloudcover,wind_speed_10m,relative_humidity_2m,uv_index",
         "hourly": "temperature_2m,cloudcover,precipitation_probability,wind_speed_10m",
         "daily": "temperature_2m_max,temperature_2m_min,precipitation_probability_max",
-        "timezone": "auto"
+        "timezone": "auto",
+        "windspeed_unit": "ms",
+        "precipitation_unit": "inch" if units == "imperial" else "mm",
     }
 
     response = requests.get(url, params=params)
@@ -61,7 +63,7 @@ def get_weather(lat, lon, units='imperial'):
     today_min = daily["temperature_2m_min"][0]
     precip_chance = daily.get("precipitation_probability_max", [0])[0]
     rain_chance = max(data['hourly']['precipitation_probability'])  # in %
-    precip_mm = data['current']['precipitation']  # in mm
+    precip_amount = data['current']['precipitation']
 
     time_index = {t: i for i, t in enumerate(hourly["time"])}
 
@@ -90,9 +92,9 @@ def get_weather(lat, lon, units='imperial'):
         "actual_temperature": round(convert_c_to_unit(temp_c), 1),
         "feels_like_temperature": round(convert_c_to_unit(feels_like_c), 1),
         "wind_speed": round(wind_speed_val),
-        "precipitation": round(precip_chance),
-        "rain_chance" : round(rain_chance),
-        "precip_mm" : round(precip_mm),
+        "precipitation": round(precip_amount, 2),
+        "precipitation_probability": round(precip_chance),
+        "rain_chance": round(rain_chance),
         "cloud_cover": round(cloud, 1),
         "humidity": round(humidity, 1),
         "uv_index": round(uv_index),
@@ -193,9 +195,9 @@ def recommend():
         "humidity": weather["humidity"],
         "cloud_cover": weather["cloud_cover"],
         "wind_speed": weather["wind_speed"],
-        "precipitation": weather["precipitation"],  # % chance
+        "precipitation": weather["precipitation"],
+        "precipitation_probability": weather["precipitation_probability"],
         "rain_chance": weather["rain_chance"],
-        "precip_mm": weather["precip_mm"],
         "uv_index": weather["uv_index"],
         "high_temp": weather["high_temp"],
         "low_temp": weather["low_temp"],

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -52,9 +52,10 @@ class _WeatherPageState extends State<WeatherPage> {
   double? humidity;
   double? cloudCover;
   double? windSpeed;
-  double? precipitation;
+  double? precipitationAmount;
   int? rainChance;
   int? uvIndex;
+  bool isImperial = true;
   List<dynamic>? outfitMorning;
   List<dynamic>? outfitAfternoon;
   List<dynamic>? outfitNight;
@@ -108,8 +109,11 @@ class _WeatherPageState extends State<WeatherPage> {
         humidity = (data['humidity'] as num?)?.toDouble();
         cloudCover = (data['cloud_cover'] as num?)?.toDouble();
         windSpeed = (data['wind_speed'] as num?)?.toDouble();
-        precipitation = (data['precipitation'] as num?)?.toDouble();
-        rainChance = (data['rain_chance'] as num?)?.toInt();
+        precipitationAmount =
+            (data['precipitation'] as num?)?.toDouble();
+        rainChance =
+            (data['precipitation_probability'] as num?)?.toInt();
+        isImperial = (data['units'] ?? '°F') == '°F';
         uvIndex = (data['uv_index'] as num?)?.toInt();
         
         // base outfit suggestions
@@ -131,7 +135,8 @@ class _WeatherPageState extends State<WeatherPage> {
       final recs = await RecommendationService.recommend(
         temp: feelsLikeTemperature ?? actualTemperature ?? 0.0,
         uvIndex: uvIndex ?? 0,
-        precipitationMm: precipitation ?? 0.0,
+        precipitationMm:
+            isImperial ? (precipitationAmount ?? 0.0) * 25.4 : precipitationAmount ?? 0.0,
         precipitationProb: rainChance ?? 0,
         topN: 5,
       );
@@ -162,7 +167,8 @@ class _WeatherPageState extends State<WeatherPage> {
     } else if (cloudCover! > 30) summary += "Partly cloudy throughout the day. ";
     else summary += "Plenty of sunshine today. ";
     if (windSpeed! > 15) summary += "It may be windy, so plan accordingly. ";
-    if (precipitation! > 1) summary += "Carry an umbrella just in case.";
+    if (precipitationAmount! > (isImperial ? 0.1 : 2))
+      summary += "Carry an umbrella just in case.";
     return summary;
   }
 
@@ -197,7 +203,8 @@ class _WeatherPageState extends State<WeatherPage> {
   }
 
   IconData getWeatherIcon() {
-    if (precipitation != null && precipitation! > 2) return WeatherIcons.rain;
+    if (precipitationAmount != null && precipitationAmount! > 0.1)
+      return WeatherIcons.rain;
     if (cloudCover != null && cloudCover! > 80) return WeatherIcons.cloudy;
     if (cloudCover != null && cloudCover! > 40) return WeatherIcons.day_cloudy;
     if (windSpeed != null && windSpeed! > 20) return WeatherIcons.strong_wind;
@@ -289,7 +296,7 @@ class _WeatherPageState extends State<WeatherPage> {
                               Text('💧 Humidity: ${humidity?.toStringAsFixed(0)}%', style: TextStyle(color: Colors.white)),
                               Text('☁️ Cloud Cover: ${cloudCover?.toStringAsFixed(0)}%', style: TextStyle(color: Colors.white)),
                               Text('🌬 Wind: ${windSpeed?.toStringAsFixed(1)} mph', style: TextStyle(color: Colors.white)),
-                              Text('🌧 Precipitation: ${precipitation?.toStringAsFixed(1)} mm (${rainChance ?? 0}%)', style: TextStyle(color: Colors.white)),
+                              Text('🌧 Precipitation: ${precipitationAmount?.toStringAsFixed(2)} ${isImperial ? 'in' : 'mm'} (${rainChance ?? 0}%)', style: TextStyle(color: Colors.white)),
                               Text('☀️ UV Index: ${uvIndex ?? 0}', style: TextStyle(color: Colors.white)),
                             ],
                           ),
@@ -330,7 +337,9 @@ class _WeatherPageState extends State<WeatherPage> {
                             builder: (_) => WardrobePage(
                               actualTemp: actualTemperature ?? 0.0,
                               uvIndex: uvIndex ?? 0,
-                              precipitationMm: precipitation ?? 0.0,
+                              precipitationMm: isImperial
+                                  ? (precipitationAmount ?? 0.0) * 25.4
+                                  : precipitationAmount ?? 0.0,
                               precipitationProb: rainChance ?? 0,
                               outfitMorning: outfitMorning?.cast<String>() ?? [],
                               outfitAfternoon: outfitAfternoon?.cast<String>() ?? [],


### PR DESCRIPTION
## Summary
- request wind speeds in m/s and convert correctly
- return precipitation amount and probability separately from the API
- display precipitation in inches when using imperial units

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q flask-cors`
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb89178408324a12deaedb30b7f07