### PR TITLE
Add history page and extended weather data

### DIFF
--- a/Backend/tests/test_app.py
+++ b/Backend/tests/test_app.py
@@ -23,19 +23,24 @@ def test_get_weather_parsing(monkeypatch):
             "cloudcover": 25,
             "relative_humidity_2m": 40,
             "uv_index": 3,
-            "precipitation": 0.1
+            "precipitation": 0.1,
+            "dew_point_2m": 5,
+            "weather_code": 2
         },
         "hourly": {
             "time": [f"{today}T08:00", f"{today}T14:00", f"{today}T20:00"],
             "temperature_2m": [12, 15, 9],
             "wind_speed_10m": [5, 6, 4],
+            "wind_gusts_10m": [7, 9, 6],
             "cloudcover": [20, 50, 60],
             "precipitation_probability": [10, 20, 30]
         },
         "daily": {
             "temperature_2m_max": [16],
             "temperature_2m_min": [8],
-            "precipitation_probability_max": [40]
+            "precipitation_probability_max": [40],
+            "sunrise": [f"{today}T06:00"],
+            "sunset": [f"{today}T18:00"]
         }
     }
 
@@ -51,8 +56,11 @@ def test_get_weather_parsing(monkeypatch):
     assert weather['city'] == 'Testville'
     assert weather['actual_temperature'] == 53.6
     assert weather['feels_like_temperature'] == 50.0
+    assert weather['dew_point'] == 41.0
+    assert weather['weather_code'] == 2
     assert weather['hourly_forecast']['morning']['temp'] == 53.6
     assert weather['hourly_forecast']['afternoon']['wind'] == 13
+    assert weather['hourly_forecast']['afternoon']['gust'] == 20
     assert weather['rain_chance'] == 30
 
 

--- a/mobile/lib/history_page.dart
+++ b/mobile/lib/history_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'storage_service.dart';
+import 'outfit_record.dart';
+
+class HistoryPage extends StatelessWidget {
+  const HistoryPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Outfit History')),
+      body: FutureBuilder<List<OutfitRecord>>( 
+        future: StorageService.loadHistory(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final history = snapshot.data!;
+          if (history.isEmpty) {
+            return const Center(child: Text('No history yet'));
+          }
+          return ListView.builder(
+            itemCount: history.length,
+            itemBuilder: (context, index) {
+              final rec = history[history.length - 1 - index];
+              final dateStr = DateFormat.yMMMEd().format(rec.date);
+              return ListTile(
+                title: Text(dateStr),
+                subtitle: Text(rec.items.join(', ')),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'wardrobe_page.dart';
+import 'history_page.dart';
 import 'package:weather_icons/weather_icons.dart';
 import 'recommendation_service.dart';
 
@@ -52,9 +53,12 @@ class _WeatherPageState extends State<WeatherPage> {
   double? humidity;
   double? cloudCover;
   double? windSpeed;
+  double? dewPoint;
   double? precipitationAmount;
   int? rainChance;
   int? uvIndex;
+  String? sunrise;
+  String? sunset;
   bool isImperial = true;
   List<dynamic>? outfitMorning;
   List<dynamic>? outfitAfternoon;
@@ -109,12 +113,15 @@ class _WeatherPageState extends State<WeatherPage> {
         humidity = (data['humidity'] as num?)?.toDouble();
         cloudCover = (data['cloud_cover'] as num?)?.toDouble();
         windSpeed = (data['wind_speed'] as num?)?.toDouble();
+        dewPoint = (data['dew_point'] as num?)?.toDouble();
         precipitationAmount =
             (data['precipitation'] as num?)?.toDouble();
         rainChance =
             (data['precipitation_probability'] as num?)?.toInt();
         isImperial = (data['units'] ?? '°F') == '°F';
         uvIndex = (data['uv_index'] as num?)?.toInt();
+        sunrise = data['sunrise'] as String?;
+        sunset = data['sunset'] as String?;
         
         // base outfit suggestions
         List<dynamic> baseOutfit = List<dynamic>.from(data['outfit'] ?? []);
@@ -298,6 +305,12 @@ class _WeatherPageState extends State<WeatherPage> {
                               Text('🌬 Wind: ${windSpeed?.toStringAsFixed(1)} mph', style: TextStyle(color: Colors.white)),
                               Text('🌧 Precipitation: ${precipitationAmount?.toStringAsFixed(2)} ${isImperial ? 'in' : 'mm'} (${rainChance ?? 0}%)', style: TextStyle(color: Colors.white)),
                               Text('☀️ UV Index: ${uvIndex ?? 0}', style: TextStyle(color: Colors.white)),
+                              if (dewPoint != null)
+                                Text('🌡 Dew Point: ${dewPoint!.toStringAsFixed(1)}°${isImperial ? 'F' : 'C'}', style: TextStyle(color: Colors.white)),
+                              if (sunrise != null)
+                                Text('🌅 Sunrise: $sunrise', style: TextStyle(color: Colors.white)),
+                              if (sunset != null)
+                                Text('🌇 Sunset: $sunset', style: TextStyle(color: Colors.white)),
                             ],
                           ),
                         ),
@@ -349,6 +362,19 @@ class _WeatherPageState extends State<WeatherPage> {
                         ),
                         icon: Icon(Icons.edit),
                         label: Text('My Wardrobe'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: themeColor,
+                          padding: EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                          textStyle: TextStyle(fontSize: 16),
+                        ),
+                      ),
+                      SizedBox(height: 10),
+                      ElevatedButton.icon(
+                        onPressed: () => Navigator.of(context).push(
+                          MaterialPageRoute(builder: (_) => const HistoryPage()),
+                        ),
+                        icon: Icon(Icons.history),
+                        label: Text('History'),
                         style: ElevatedButton.styleFrom(
                           backgroundColor: themeColor,
                           padding: EdgeInsets.symmetric(horizontal: 24, vertical: 12),

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -35,7 +35,8 @@ dependencies:
   flutter_spinkit: ^5.2.0 
   flutter_local_notifications: ^17.1.0
   weather_icons: ^3.0.0
-  shared_preferences: ^2.0.0 
+  shared_preferences: ^2.0.0
+  intl: ^0.19.0
     
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- extend backend weather fields (dew point, weather code, gusts, sunrise/sunset)
- update tests for new weather fields
- parse new weather info in Flutter app
- add outfit history page and navigation button
- allow manual entry of morning/afternoon/night outfits in wardrobe page
- include `intl` package for date formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbc6974cc8324b90c30939ca9de00